### PR TITLE
Switch backends from RoundTrippers to Handlers

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -1,27 +1,20 @@
 package fastlike
 
 import (
-	"bytes"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 )
 
-// Backend is a function used to send requests to a backend
-type Backend func(*http.Request) (*http.Response, error)
-
-// BackendHandler is a function that takes a backend name and returns a Backend function
-type BackendHandler func(backend string) Backend
+// BackendHandler is a function that takes a backend name and returns an http.Handler that can
+// satisfy that backend
+type BackendHandler func(backend string) http.Handler
 
 func defaultBackendHandler() BackendHandler {
-	return func(backend string) Backend {
-		return func(_ *http.Request) (*http.Response, error) {
+	return func(backend string) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadGateway)
 			var msg = fmt.Sprintf(`Unknown backend '%s'. Did you configure your backends correctly?`, backend)
-			return &http.Response{
-				Status:     http.StatusText(http.StatusBadGateway),
-				StatusCode: http.StatusBadGateway,
-				Body:       ioutil.NopCloser(bytes.NewBufferString(msg)),
-			}, nil
-		}
+			w.Write([]byte(msg))
+		})
 	}
 }

--- a/instance.go
+++ b/instance.go
@@ -38,7 +38,7 @@ type Instance struct {
 
 	// geobackend is a backend for geographic requests
 	// these are issued by the guest when you attempt to lookup geo data
-	geobackend Backend
+	geobackend http.Handler
 
 	uaparser UserAgentParser
 

--- a/options.go
+++ b/options.go
@@ -16,7 +16,7 @@ func BackendHandlerOption(b BackendHandler) InstanceOption {
 }
 
 // GeoHandlerOption is an InstanceOption which controls how geographic requests are handled
-func GeoHandlerOption(b Backend) InstanceOption {
+func GeoHandlerOption(b http.Handler) InstanceOption {
 	return func(i *Instance) {
 		i.geobackend = b
 	}


### PR DESCRIPTION
Originally, this project used http.Handler for the backend type, but I switched
to http.RoundTripper because I thought the general use-case would be sending
fastlike subrequests to another process.

While I still believe that to be generally true, having backends be Handlers is
simpler for embedders that want to respond in-process, and it's very easy to
create a reverse proxy to send requests upstream that still implements the
`Handler` interface.