### PR TITLE
Update to latest versions of wasmtime-go and fastly.rs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+.PHONY: build
+.PHONY: clean
+
+testdata/bin/main.wasm:
+	cd testdata; \
+	fastly compute build
+
+build: testdata/bin/main.wasm
+
+clean:
+	rm -rf testdata/bin/main.wasm

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,13 @@
-.PHONY: build
-.PHONY: clean
+.PHONY: build clean test
 
 testdata/bin/main.wasm:
 	cd testdata; \
 	fastly compute build
 
 build: testdata/bin/main.wasm
+
+test:
+	gotestsum ./... -race
 
 clean:
 	rm -rf testdata/bin/main.wasm

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ For a more full-featured example:
 ```
 # in one terminal:
 $ cd testdata; fastly compute build; cd ..
-$ go run ./cmd/fastlike -wasm ./testdata/bin/main.wasm -proxy-to localhost:8000 -bind localhost:5000
+$ go run ./cmd/fastlike -wasm ./testdata/bin/main.wasm -proxy-to localhost:8000 -b localhost:5000
 
 # in another
 $ python3 -m http.server

--- a/constants.go
+++ b/constants.go
@@ -1,7 +1,10 @@
 package fastlike
 
 // XqdStatus is a status code returned from every XQD ABI method as described in crate
-// `fastly-shared`
+// `fastly-shared`. Unfortunately, the version of wasmtime that we're using
+// fails the function type check if we use this as the return type from all of
+// the exported functions. Instead, we now have to return `int32` and case the
+// constants below when returning them. (eg. `return int32(XqdStatusOK)`).
 type XqdStatus int32
 
 const (

--- a/doc.go
+++ b/doc.go
@@ -1,4 +1,4 @@
-// package fastlike is a Go implementation of the Fastly Compute@Edge XQD ABI.
+// package fastlike is a Go implementation of the Fastly Compute@Edge ABI.
 //
 // It is designed to be used as an `http.Handler`, and has a `ServeHTTP` method to accomodate.
 // The ABI is designed around a single instance handling a single request and response pair. This
@@ -8,16 +8,19 @@
 // a single (request, response) pair and any fiddling with the internals can cause serious
 // side-effects.
 //
-// XQD ABI
-// The XQD ABI is the interface between a Compute wasm program and the host. In production, the
+// fastly-sys ABI
+// The fastly-sys ABI is the interface between a Compute wasm program and the host. In production, the
 // host is Fastly's Compute platform. Fastlike is an alternative implementation of the host.
 //
-// At time of writing, the ABI is not a public, documented spec. This implementation was done by
-// looking at the source code of the fastly rust crate, particularly [abi.rs] and [lib.rs] for
-// some constants.
+// The ABI is defined by the [fastly-sys](https://docs.rs/fastly-sys) crate. Note that the types
+// defined in the Rust crate map to WASM types but may not always be identical. For example, in most
+// cases, the Go type for an integral value is `int`. It is possible to derive the exact signature for
+// a function by running `wasm2wat` (from the Web Assembly Binary Toolkit) on the generated wasm blob,
+// finding the function in question, and then looking up it's type earlier in the listing.
 //
-// Our implementation of the ABI is in xqd*.go, and it's linked to your wasm program via the `linker`
-// method of the Instance type, implemented in instance.go.
+// Our implementation of the ABI is in xqd*.go (prior to the `fastly-sys` crate being published, the
+// ABI was referred to as the XQD API, not its simply the set of `fastly_*` modules), and it's linked
+// to your wasm program via the `linker` method of the Instance type, implemented in instance.go.
 //
 // Each ABI method purposefully follows the signatures defined on the guest-side to make it easy to
 // compare. It's not idiomatic Go by design.

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/Khan/fastlike
 
-go 1.13
+go 1.14
 
-require github.com/bytecodealliance/wasmtime-go v0.16.2
+require github.com/bytecodealliance/wasmtime-go v0.26.1

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/bytecodealliance/wasmtime-go v0.16.2 h1:lrPRSZzl6MSTEfspH6JLGwXwz/TFlJXHfpgVl1T698I=
-github.com/bytecodealliance/wasmtime-go v0.16.2/go.mod h1:q320gUxqyI8yB+ZqRuaJOEnGkAnHh6WtJjMaT2CW4wI=
+github.com/bytecodealliance/wasmtime-go v0.26.1 h1:xDzNH+Iq5o4N27pmsvB8cY35feN3H4d3bS7RjddBPWQ=
+github.com/bytecodealliance/wasmtime-go v0.26.1/go.mod h1:q320gUxqyI8yB+ZqRuaJOEnGkAnHh6WtJjMaT2CW4wI=

--- a/handles.go
+++ b/handles.go
@@ -115,17 +115,13 @@ func NewBodyHandles() *BodyHandles {
 	return &BodyHandles{handles: make(map[int]*BodyHandle)}
 }
 
-func (bhs *BodyHandles) getNextHandleID() int {
-	handleID := bhs.nextHandleID
-	bhs.nextHandleID += 1
-	return handleID
-}
-
 func (bhs *BodyHandles) addBodyHandle(bh *BodyHandle) (int, *BodyHandle) {
 	bhs.lock.Lock()
 	defer bhs.lock.Unlock()
 
-	id := bhs.getNextHandleID()
+	id := bhs.nextHandleID
+	bhs.nextHandleID += 1
+
 	bhs.handles[id] = bh
 
 	return id, bh

--- a/instance.go
+++ b/instance.go
@@ -55,7 +55,7 @@ func NewInstance(wasmbytes []byte, opts ...InstanceOption) *Instance {
 	i.compile(wasmbytes)
 
 	i.requests = &RequestHandles{}
-	i.bodies = &BodyHandles{}
+	i.bodies = NewBodyHandles()
 	i.responses = &ResponseHandles{}
 
 	i.log = log.New(ioutil.Discard, "[fastlike] ", log.Lshortfile)
@@ -108,7 +108,7 @@ func (i *Instance) reset() {
 	// reset the handles, but we can reuse the already allocated space
 	*i.requests = RequestHandles{}
 	*i.responses = ResponseHandles{}
-	*i.bodies = BodyHandles{}
+	*i.bodies = *NewBodyHandles()
 
 	i.ds_response = nil
 	i.ds_request = nil

--- a/instance.go
+++ b/instance.go
@@ -51,7 +51,7 @@ type Instance struct {
 
 // NewInstance returns an http.Handler that can handle a single request.
 func NewInstance(wasmbytes []byte, opts ...InstanceOption) *Instance {
-	var i = new(Instance)
+	i := new(Instance)
 	i.compile(wasmbytes)
 
 	i.requests = &RequestHandles{}
@@ -132,12 +132,12 @@ func (i *Instance) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	i.setup()
 	defer i.reset()
 
-	var loops, ok = r.Header[http.CanonicalHeaderKey("cdn-loop")]
+	loops, ok := r.Header[http.CanonicalHeaderKey("cdn-loop")]
 	if !ok {
 		loops = []string{""}
 	}
 
-	var _, yeslog = r.Header[http.CanonicalHeaderKey("fastlike-verbose")]
+	_, yeslog := r.Header[http.CanonicalHeaderKey("fastlike-verbose")]
 	if yeslog {
 		i.abilog.SetOutput(os.Stdout)
 	}

--- a/testdata/Cargo.lock
+++ b/testdata/Cargo.lock
@@ -21,8 +21,8 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "cfg-if"
-version = "0.1.10"
+name = "bytes"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -39,54 +39,57 @@ dependencies = [
 name = "fastlike-example"
 version = "0.1.0"
 dependencies = [
- "fastly 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fastly 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.52 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "fastly"
-version = "0.3.3"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "anyhow 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "fastly-macros 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "fastly-shared 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "fastly-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "http 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fastly-macros 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fastly-shared 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fastly-sys 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mime 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.52 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_urlencoded 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "fastly-macros"
-version = "0.3.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "fastly-shared"
-version = "0.3.2"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "http 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "fastly-sys"
-version = "0.3.3"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "fastly-shared 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fastly-shared 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -95,13 +98,32 @@ version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "http"
-version = "0.2.1"
+name = "form_urlencoded"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "http"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bytes 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "itoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "idna"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-bidi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-normalization 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -115,12 +137,14 @@ version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "log"
-version = "0.4.8"
+name = "matches"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
-]
+
+[[package]]
+name = "mime"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "num-integer"
@@ -140,8 +164,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "percent-encoding"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "proc-macro2"
-version = "1.0.10"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -152,7 +181,7 @@ name = "quote"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -173,9 +202,9 @@ name = "serde_derive"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -189,31 +218,71 @@ dependencies = [
 ]
 
 [[package]]
-name = "syn"
-version = "1.0.17"
+name = "serde_urlencoded"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "form_urlencoded 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ryu 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "syn"
+version = "1.0.71"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "thiserror"
-version = "1.0.14"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "thiserror-impl 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror-impl 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.14"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "tinyvec_macros 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "tinyvec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -221,31 +290,52 @@ name = "unicode-xid"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
+[[package]]
+name = "url"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "form_urlencoded 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "idna 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
 [metadata]
 "checksum anyhow 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)" = "d9a60d744a80c30fcb657dfe2c1b22bcb3e814c1a1e3674f32bf5820b570fbff"
 "checksum autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
 "checksum bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 "checksum bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "130aac562c0dd69c56b3b1cc8ffd2e17be31d0b6c25b61c96b76231aa23e39e1"
-"checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+"checksum bytes 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
 "checksum chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "80094f509cf8b5ae86a4966a39b3ff66cd7e2a3e594accec3743ff3fabeab5b2"
-"checksum fastly 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "5f865c5fb31249de9b181721a02ecdc66ef39c68d7e715c65265266cdc6fe9f7"
-"checksum fastly-macros 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "aa02f752373481e7f21db28482670b05c94476418614f3aef57c3c0459470b47"
-"checksum fastly-shared 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "057adc3b19851383cf03ce9020318ee6eabb8f0b187987e916417b444583f8d5"
-"checksum fastly-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6206b617d4124353ea6b2cbe3e9910409dc321f4bdb2d467fb40bc6e9eafaeec"
+"checksum fastly 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b902d81a7be2a0bfc504bf82e5f28db32da16c390e4a40660b66fa9ba0d21012"
+"checksum fastly-macros 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f46f7f93d61e27761c23c1b613b130d3e37803df0d472ac70d899a6e0bf98480"
+"checksum fastly-shared 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c37497a50d8f8f4d8adbfeadc203606c5b3127d3a006058a4303912e0fc86cd2"
+"checksum fastly-sys 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1a62f76ee7ad35f28e2e2b84a36dd6f1781dd61a139151f3550bd539714b22f0"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
-"checksum http 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "28d569972648b2c512421b5f2a405ad6ac9666547189d0c5477a3f200f3e02f9"
+"checksum form_urlencoded 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
+"checksum http 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "527e8c9ac747e28542699a951517aa9a6945af506cd1f2e1b53a576c17b6cc11"
+"checksum idna 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
 "checksum itoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-"checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
+"checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
+"checksum mime 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)" = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 "checksum num-integer 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "3f6ea62e9d81a77cd3ee9a2a5b9b609447857f3d358704331e4ef39eb247fcba"
 "checksum num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "c62be47e61d1842b9170f0fdeec8eba98e60e90e5446449a0545e5152acd7096"
-"checksum proc-macro2 1.0.10 (registry+https://github.com/rust-lang/crates.io-index)" = "df246d292ff63439fea9bc8c0a270bed0e390d5ebd4db4ba15aba81111b5abe3"
+"checksum percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+"checksum proc-macro2 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)" = "a152013215dca273577e18d2bf00fa862b89b24169fb78c4c95aeb07992c9cec"
 "checksum quote 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2bdc6c187c65bca4260c9011c9e3132efe4909da44726bad24cf7572ae338d7f"
 "checksum ryu 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "ed3d612bc64430efeb3f7ee6ef26d590dce0c43249217bddc62112540c7941e1"
 "checksum serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)" = "36df6ac6412072f67cf767ebbde4133a5b2e88e76dc6187fa7104cd16f783399"
 "checksum serde_derive 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)" = "9e549e3abf4fb8621bd1609f11dfc9f5e50320802273b12f3811a67e6716ea6c"
 "checksum serde_json 1.0.52 (registry+https://github.com/rust-lang/crates.io-index)" = "a7894c8ed05b7a3a279aeb79025fdec1d3158080b75b98a08faf2806bb799edd"
-"checksum syn 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)" = "0df0eb663f387145cab623dea85b09c2c5b4b0aef44e945d928e682fce71bb03"
-"checksum thiserror 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)" = "f0570dc61221295909abdb95c739f2e74325e14293b2026b0a7e195091ec54ae"
-"checksum thiserror-impl 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)" = "227362df41d566be41a28f64401e07a043157c21c14b9785a0d8e256f940a8fd"
+"checksum serde_urlencoded 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "edfa57a7f8d9c1d260a549e7224100f6c43d43f9103e06dd8b4095a9b2b43ce9"
+"checksum syn 1.0.71 (registry+https://github.com/rust-lang/crates.io-index)" = "ad184cc9470f9117b2ac6817bfe297307418819ba40552f9b3846f05c33d5373"
+"checksum thiserror 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)" = "e0f4a65597094d4483ddaed134f409b2cb7c1beccf25201a9f73c719254fa98e"
+"checksum thiserror-impl 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)" = "7765189610d8241a44529806d6fd1f2e0a08734313a35d5b3a556f92b381f3c0"
+"checksum tinyvec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5b5220f05bb7de7f3f53c7c065e1199b3172696fe2db9f9c4d8ad9b4ee74c342"
+"checksum tinyvec_macros 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
+"checksum unicode-bidi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "eeb8be209bb1c96b7c177c7420d26e04eccacb0eeae6b980e35fcb74678107e0"
+"checksum unicode-normalization 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)" = "07fbfce1c8a97d547e8b5334978438d9d6ec8c20e38f56d4a4374d181493eaef"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
+"checksum url 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9ccd964113622c8e9322cfac19eb1004a07e636c545f325da085d5cdde6f1f8b"

--- a/testdata/Cargo.toml
+++ b/testdata/Cargo.toml
@@ -8,5 +8,5 @@ edition = "2018"
 debug = true
 
 [dependencies]
-fastly = "^0.3.3"
+fastly = "^0.7"
 serde_json = "*"

--- a/testdata/fastly.toml
+++ b/testdata/fastly.toml
@@ -1,6 +1,9 @@
-version = 1
-name = "fastlike-example"
-description = "An example program for the Fastlike implementation"
+# This file describes a Fastly Compute@Edge package. To learn more visit:
+# https://developer.fastly.com/reference/fastly-toml/
+
 authors = ["alexvidal@khanacademy.org", "infrastructure@khanacademy.org"]
+description = "An example program for the Fastlike implementation"
 language = "rust"
+manifest_version = 1
+name = "fastlike-example"
 service_id = "5PjBZ4C4pQyearWZGuTxoG"

--- a/testdata/rust-toolchain
+++ b/testdata/rust-toolchain
@@ -1,1 +1,3 @@
-1.43.0
+[toolchain]
+channel = "1.51.0"
+targets = [ "wasm32-wasi" ]

--- a/wasmcontext.go
+++ b/wasmcontext.go
@@ -18,7 +18,7 @@ func (i *Instance) compile(wasmbytes []byte) {
 	config.SetInterruptable(true)
 
 	store := wasmtime.NewStore(wasmtime.NewEngineWithConfig(config))
-	module, err := wasmtime.NewModule(store, wasmbytes)
+	module, err := wasmtime.NewModule(store.Engine, wasmbytes)
 	check(err)
 
 	wasicfg := wasmtime.NewWasiConfig()
@@ -34,72 +34,74 @@ func (i *Instance) compile(wasmbytes []byte) {
 	// XQD Stubbing -{{{
 	// TODO: All of these XQD methods are stubbed. As they are implemented, they'll be removed from
 	// here and explicitly linked in the section below.
-	linker.DefineFunc("env", "xqd_log_endpoint_get", i.wasm3("xqd_log_endpoint_get"))
-	linker.DefineFunc("env", "xqd_log_write", i.wasm4("xqd_log_write"))
+	linker.DefineFunc("fastly_log", "endpoint_get", i.wasm3("fastly_log::endpoint_get"))
+	linker.DefineFunc("fastly_log", "write", i.wasm4("fastly_log::write"))
 
-	linker.DefineFunc("env", "xqd_pending_req_poll", i.wasm4("xqd_pending_req_poll"))
-	linker.DefineFunc("env", "xqd_pending_req_select", i.wasm5("xqd_pending_req_select"))
-	linker.DefineFunc("env", "xqd_pending_req_wait", i.wasm3("xqd_pending_req_wait"))
+	linker.DefineFunc("fastly_http_req", "pending_req_poll", i.wasm4("fastly_http_req::pending_req_poll"))
+	linker.DefineFunc("fastly_http_req", "pending_req_select", i.wasm5("fastly_http_req::pending_req_select"))
+	linker.DefineFunc("fastly_http_req", "pending_req_wait", i.wasm3("fastly_http_req::pending_req_wait"))
 
-	linker.DefineFunc("env", "xqd_req_downstream_tls_cipher_openssl_name", i.wasm3("xqd_req_downstream_tls_cipher_openssl_name"))
-	linker.DefineFunc("env", "xqd_req_downstream_tls_protocol", i.wasm3("xqd_req_downstream_tls_protocol"))
-	linker.DefineFunc("env", "xqd_req_downstream_tls_client_hello", i.wasm3("xqd_req_downstream_tls_client_hello"))
+	linker.DefineFunc("fastly_http_req", "req_downstream_tls_cipher_openssl_name", i.wasm3("fastly_http_req::req_downstream_tls_cipher_openssl_name"))
+	linker.DefineFunc("fastly_http_req", "req_downstream_tls_protocol", i.wasm3("fastly_http_req::req_downstream_tls_protocol"))
+	linker.DefineFunc("fastly_http_req", "req_downstream_tls_client_hello", i.wasm3("fastly_http_req::req_downstream_tls_client_hello"))
 
-	linker.DefineFunc("env", "xqd_req_header_insert", i.wasm5("xqd_req_header_insert"))
-	linker.DefineFunc("env", "xqd_req_send_async", i.wasm5("xqd_req_send_async"))
+	linker.DefineFunc("fastly_http_req", "req_header_insert", i.wasm5("fastly_http_req::req_header_insert"))
+	linker.DefineFunc("fastly_http_req", "req_send_async", i.wasm5("fastly_http_req::req_send_async"))
 
-	linker.DefineFunc("env", "xqd_req_original_header_count", i.wasm1("xqd_req_original_header_count"))
-	linker.DefineFunc("env", "xqd_req_header_remove", i.wasm3("xqd_req_header_remove"))
+	linker.DefineFunc("fastly_http_req", "req_original_header_count", i.wasm1("fastly_http_req::req_original_header_count"))
+	linker.DefineFunc("fastly_http_req", "req_header_remove", i.wasm3("fastly_http_req::req_header_remove"))
 
-	linker.DefineFunc("env", "xqd_resp_header_append", i.wasm5("xqd_resp_header_append"))
-	linker.DefineFunc("env", "xqd_resp_header_insert", i.wasm5("xqd_resp_header_insert"))
-	linker.DefineFunc("env", "xqd_resp_header_value_get", i.wasm6("xqd_resp_header_value_get"))
-	linker.DefineFunc("env", "xqd_resp_header_remove", i.wasm3("xqd_resp_header_remove"))
+	linker.DefineFunc("fastly_http_resp", "resp_header_append", i.wasm5("fastly_http_resp::resp_header_append"))
+	linker.DefineFunc("fastly_http_resp", "resp_header_insert", i.wasm5("fastly_http_resp::resp_header_insert"))
+	linker.DefineFunc("fastly_http_resp", "resp_header_value_get", i.wasm6("fastly_http_resp::resp_header_value_get"))
+	linker.DefineFunc("fastly_http_resp", "resp_header_remove", i.wasm3("fastly_http_resp::resp_header_remove"))
 
-	linker.DefineFunc("env", "xqd_body_close_downstream", i.wasm1("xqd_body_close_downstream"))
+	linker.DefineFunc("fastly_http_body", "close", i.wasm1("fastly_http_body::close"))
 
 	// End XQD Stubbing -}}}
 
 	// xqd.go
-	linker.DefineFunc("fastly", "init", i.xqd_init)
+	linker.DefineFunc("fastly_abi", "init", i.xqd_init)
 	linker.DefineFunc("fastly_uap", "parse", i.xqd_uap_parse)
 
-	linker.DefineFunc("env", "xqd_req_body_downstream_get", i.xqd_req_body_downstream_get)
-	linker.DefineFunc("env", "xqd_resp_send_downstream", i.xqd_resp_send_downstream)
-	linker.DefineFunc("env", "xqd_req_downstream_client_ip_addr", i.xqd_req_downstream_client_ip_addr)
+	linker.DefineFunc("fastly_http_req", "body_downstream_get", i.xqd_req_body_downstream_get)
+	linker.DefineFunc("fastly_http_resp", "send_downstream", i.xqd_resp_send_downstream)
+	linker.DefineFunc("fastly_http_req", "downstream_client_ip_addr", i.xqd_req_downstream_client_ip_addr)
 
 	// xqd_request.go
-	linker.DefineFunc("env", "xqd_req_new", i.xqd_req_new)
-	linker.DefineFunc("env", "xqd_req_version_get", i.xqd_req_version_get)
-	linker.DefineFunc("env", "xqd_req_version_set", i.xqd_req_version_set)
-	linker.DefineFunc("env", "xqd_req_method_get", i.xqd_req_method_get)
-	linker.DefineFunc("env", "xqd_req_method_set", i.xqd_req_method_set)
-	linker.DefineFunc("env", "xqd_req_uri_get", i.xqd_req_uri_get)
-	linker.DefineFunc("env", "xqd_req_uri_set", i.xqd_req_uri_set)
-	linker.DefineFunc("env", "xqd_req_header_names_get", i.xqd_req_header_names_get)
-	linker.DefineFunc("env", "xqd_req_header_values_get", i.xqd_req_header_values_get)
-	linker.DefineFunc("env", "xqd_req_header_values_set", i.xqd_req_header_values_set)
-	linker.DefineFunc("env", "xqd_req_send", i.xqd_req_send)
-	linker.DefineFunc("env", "xqd_req_cache_override_set", i.xqd_req_cache_override_set)
+	linker.DefineFunc("fastly_http_req", "new", i.xqd_req_new)
+	linker.DefineFunc("fastly_http_req", "version_get", i.xqd_req_version_get)
+	linker.DefineFunc("fastly_http_req", "version_set", i.xqd_req_version_set)
+	linker.DefineFunc("fastly_http_req", "method_get", i.xqd_req_method_get)
+	linker.DefineFunc("fastly_http_req", "method_set", i.xqd_req_method_set)
+	linker.DefineFunc("fastly_http_req", "uri_get", i.xqd_req_uri_get)
+	linker.DefineFunc("fastly_http_req", "uri_set", i.xqd_req_uri_set)
+	linker.DefineFunc("fastly_http_req", "header_names_get", i.xqd_req_header_names_get)
+	linker.DefineFunc("fastly_http_req", "header_values_get", i.xqd_req_header_values_get)
+	linker.DefineFunc("fastly_http_req", "header_values_set", i.xqd_req_header_values_set)
+	linker.DefineFunc("fastly_http_req", "send", i.xqd_req_send)
+	linker.DefineFunc("fastly_http_req", "cache_override_set", i.xqd_req_cache_override_set)
+	linker.DefineFunc("fastly_http_req", "cache_override_v2_set", i.xqd_req_cache_override_set_v2)
+
 	// The Go http implementation doesn't make it easy to get at the original headers in order, so
 	// we just use the same sorted order
-	linker.DefineFunc("env", "xqd_req_original_header_names_get", i.xqd_req_header_names_get)
+	linker.DefineFunc("fastly_http_req", "original_header_names_get", i.xqd_req_header_names_get)
 
 	// xqd_response.go
-	linker.DefineFunc("env", "xqd_resp_new", i.xqd_resp_new)
-	linker.DefineFunc("env", "xqd_resp_status_get", i.xqd_resp_status_get)
-	linker.DefineFunc("env", "xqd_resp_status_set", i.xqd_resp_status_set)
-	linker.DefineFunc("env", "xqd_resp_version_get", i.xqd_resp_version_get)
-	linker.DefineFunc("env", "xqd_resp_version_set", i.xqd_resp_version_set)
-	linker.DefineFunc("env", "xqd_resp_header_names_get", i.xqd_resp_header_names_get)
-	linker.DefineFunc("env", "xqd_resp_header_values_get", i.xqd_resp_header_values_get)
-	linker.DefineFunc("env", "xqd_resp_header_values_set", i.xqd_resp_header_values_set)
+	linker.DefineFunc("fastly_http_resp", "new", i.xqd_resp_new)
+	linker.DefineFunc("fastly_http_resp", "status_get", i.xqd_resp_status_get)
+	linker.DefineFunc("fastly_http_resp", "status_set", i.xqd_resp_status_set)
+	linker.DefineFunc("fastly_http_resp", "version_get", i.xqd_resp_version_get)
+	linker.DefineFunc("fastly_http_resp", "version_set", i.xqd_resp_version_set)
+	linker.DefineFunc("fastly_http_resp", "header_names_get", i.xqd_resp_header_names_get)
+	linker.DefineFunc("fastly_http_resp", "header_values_get", i.xqd_resp_header_values_get)
+	linker.DefineFunc("fastly_http_resp", "header_values_set", i.xqd_resp_header_values_set)
 
 	// xqd_body.go
-	linker.DefineFunc("env", "xqd_body_new", i.xqd_body_new)
-	linker.DefineFunc("env", "xqd_body_write", i.xqd_body_write)
-	linker.DefineFunc("env", "xqd_body_read", i.xqd_body_read)
-	linker.DefineFunc("env", "xqd_body_append", i.xqd_body_append)
+	linker.DefineFunc("fastly_http_body", "new", i.xqd_body_new)
+	linker.DefineFunc("fastly_http_body", "read", i.xqd_body_read)
+	linker.DefineFunc("fastly_http_body", "write", i.xqd_body_write)
+	linker.DefineFunc("fastly_http_body", "append", i.xqd_body_append)
 
 	i.wasmctx = &wasmContext{
 		store:  store,

--- a/wasmcontext.go
+++ b/wasmcontext.go
@@ -31,9 +31,10 @@ func (i *Instance) compile(wasmbytes []byte) {
 	linker := wasmtime.NewLinker(store)
 	check(linker.DefineWasi(wasi))
 
-	// XQD Stubbing -{{{
-	// TODO: All of these XQD methods are stubbed. As they are implemented, they'll be removed from
-	// here and explicitly linked in the section below.
+	// fastly-sys Stubbing -{{{
+	// TODO: All of these fastly-sys methods are stubbed. As they are
+	// implemented, they'll be removed from here and explicitly linked in the
+	// section below.
 	linker.DefineFunc("fastly_log", "endpoint_get", i.wasm3("fastly_log::endpoint_get"))
 	linker.DefineFunc("fastly_log", "write", i.wasm4("fastly_log::write"))
 
@@ -56,7 +57,7 @@ func (i *Instance) compile(wasmbytes []byte) {
 	linker.DefineFunc("fastly_http_resp", "resp_header_value_get", i.wasm6("fastly_http_resp::resp_header_value_get"))
 	linker.DefineFunc("fastly_http_resp", "resp_header_remove", i.wasm3("fastly_http_resp::resp_header_remove"))
 
-	// End XQD Stubbing -}}}
+	// End fastly-sys Stubbing -}}}
 
 	// xqd.go
 	linker.DefineFunc("fastly_abi", "init", i.xqd_init)

--- a/wasmcontext.go
+++ b/wasmcontext.go
@@ -56,8 +56,6 @@ func (i *Instance) compile(wasmbytes []byte) {
 	linker.DefineFunc("fastly_http_resp", "resp_header_value_get", i.wasm6("fastly_http_resp::resp_header_value_get"))
 	linker.DefineFunc("fastly_http_resp", "resp_header_remove", i.wasm3("fastly_http_resp::resp_header_remove"))
 
-	linker.DefineFunc("fastly_http_body", "close", i.wasm1("fastly_http_body::close"))
-
 	// End XQD Stubbing -}}}
 
 	// xqd.go
@@ -102,6 +100,7 @@ func (i *Instance) compile(wasmbytes []byte) {
 	linker.DefineFunc("fastly_http_body", "read", i.xqd_body_read)
 	linker.DefineFunc("fastly_http_body", "write", i.xqd_body_write)
 	linker.DefineFunc("fastly_http_body", "append", i.xqd_body_append)
+	linker.DefineFunc("fastly_http_body", "close", i.xqd_body_close)
 
 	i.wasmctx = &wasmContext{
 		store:  store,

--- a/xqd_body.go
+++ b/xqd_body.go
@@ -5,21 +5,21 @@ import (
 	"io"
 )
 
-func (i *Instance) xqd_body_new(handle_out int32) XqdStatus {
-	var bhid, _ = i.bodies.NewBuffer()
+func (i *Instance) xqd_body_new(handle_out int32) int32 {
+	bhid, _ := i.bodies.NewBuffer()
 	i.abilog.Printf("body_new: handle=%d", bhid)
 	i.memory.PutUint32(uint32(bhid), int64(handle_out))
-	return XqdStatusOK
+	return int32(XqdStatusOK)
 }
 
-func (i *Instance) xqd_body_write(handle int32, addr int32, size int32, body_end int32, nwritten_out int32) XqdStatus {
+func (i *Instance) xqd_body_write(handle int32, addr int32, size int32, body_end int32, nwritten_out int32) int32 {
 	// TODO: Figure out what we're supposed to do with `body_end` which can be 0 (back) or
 	// 1 (front)
 	i.abilog.Printf("body_write: handle=%d size=%d, body_end=%d", handle, size, body_end)
 
-	var body = i.bodies.Get(int(handle))
+	body := i.bodies.Get(int(handle))
 	if body == nil {
-		return XqdErrInvalidHandle
+		return int32(XqdErrInvalidHandle)
 	}
 
 	// Copy size bytes starting at addr into the body handle
@@ -27,37 +27,37 @@ func (i *Instance) xqd_body_write(handle int32, addr int32, size int32, body_end
 	if err != nil {
 		// TODO: If err == EOF then there's a specific error code we can return (it means they
 		// didn't have `size` bytes in memory)
-		return XqdError
+		return int32(XqdError)
 	}
 
 	// Write out how many bytes we copied
 	i.memory.PutUint32(uint32(nwritten), int64(nwritten_out))
 
-	return XqdStatusOK
+	return int32(XqdStatusOK)
 }
 
-func (i *Instance) xqd_body_read(handle int32, addr int32, maxlen int32, nread_out int32) XqdStatus {
-	var body = i.bodies.Get(int(handle))
+func (i *Instance) xqd_body_read(handle int32, addr int32, maxlen int32, nread_out int32) int32 {
+	body := i.bodies.Get(int(handle))
 	if body == nil {
-		return XqdErrInvalidHandle
+		return int32(XqdErrInvalidHandle)
 	}
 
-	var buf = bytes.NewBuffer(make([]byte, 0, maxlen))
-	var ncopied, err = io.Copy(buf, io.LimitReader(body, int64(maxlen)))
+	buf := bytes.NewBuffer(make([]byte, 0, maxlen))
+	ncopied, err := io.Copy(buf, io.LimitReader(body, int64(maxlen)))
 	if err != nil {
 		i.abilog.Printf("body_read: error copying got=%s", err.Error())
-		return XqdError
+		return int32(XqdError)
 	}
 
-	var nwritten, err2 = i.memory.WriteAt(buf.Bytes(), int64(addr))
+	nwritten, err2 := i.memory.WriteAt(buf.Bytes(), int64(addr))
 	if err2 != nil {
 		i.abilog.Printf("body_read: error writing got=%s", err2.Error())
-		return XqdError
+		return int32(XqdError)
 	}
 
 	if ncopied != int64(nwritten) {
 		i.abilog.Printf("body_read: error copying copied=%d wrote=%d", ncopied, nwritten)
-		return XqdError
+		return int32(XqdError)
 	}
 
 	i.abilog.Printf("body_read: handle=%d copied=%d", handle, ncopied)
@@ -65,25 +65,25 @@ func (i *Instance) xqd_body_read(handle int32, addr int32, maxlen int32, nread_o
 	// Write out how many bytes we copied
 	i.memory.PutUint32(uint32(nwritten), int64(nread_out))
 
-	return XqdStatusOK
+	return int32(XqdStatusOK)
 }
 
-func (i *Instance) xqd_body_append(dst_handle int32, src_handle int32) XqdStatus {
+func (i *Instance) xqd_body_append(dst_handle int32, src_handle int32) int32 {
 	i.abilog.Printf("body_append: dst=%d src=%d", dst_handle, src_handle)
 
-	var dst = i.bodies.Get(int(dst_handle))
+	dst := i.bodies.Get(int(dst_handle))
 	if dst == nil {
-		return XqdErrInvalidHandle
+		return int32(XqdErrInvalidHandle)
 	}
 
-	var src = i.bodies.Get(int(src_handle))
+	src := i.bodies.Get(int(src_handle))
 	if src == nil {
-		return XqdErrInvalidHandle
+		return int32(XqdErrInvalidHandle)
 	}
 
 	// replace the destination reader with a multireader that reads first from the original reader
 	// and then from the source
 	dst.reader = io.MultiReader(dst.reader, src)
 
-	return XqdStatusOK
+	return int32(XqdStatusOK)
 }

--- a/xqd_body.go
+++ b/xqd_body.go
@@ -87,3 +87,9 @@ func (i *Instance) xqd_body_append(dst_handle int32, src_handle int32) int32 {
 
 	return int32(XqdStatusOK)
 }
+
+func (i *Instance) xqd_body_close(handle int32) int32 {
+	i.abilog.Printf("body_close")
+
+	return int32(XqdStatusOK)
+}

--- a/xqd_body.go
+++ b/xqd_body.go
@@ -91,5 +91,7 @@ func (i *Instance) xqd_body_append(dst_handle int32, src_handle int32) int32 {
 func (i *Instance) xqd_body_close(handle int32) int32 {
 	i.abilog.Printf("body_close")
 
+	i.bodies.Close(int(handle))
+
 	return int32(XqdStatusOK)
 }

--- a/xqd_multivalue.go
+++ b/xqd_multivalue.go
@@ -3,14 +3,14 @@ package fastlike
 // xqd_multivalue is not an actual ABI method, but it's an implementation of a mechanism used by
 // the guest to make multiple hostcalls via a cursor
 // For usage, see the abi methods for headers
-func xqd_multivalue(memory *Memory, data []string, addr int32, maxlen int32, cursor int32, ending_cursor_out int32, nwritten_out int32) XqdStatus {
+func xqd_multivalue(memory *Memory, data []string, addr int32, maxlen int32, cursor int32, ending_cursor_out int32, nwritten_out int32) int32 {
 	// If there's no data, return early
 	if len(data) == 0 {
 		memory.PutUint32(uint32(0), int64(nwritten_out))
 
 		// Set the cursor to -1 to stop asking
 		memory.PutInt64(-1, int64(ending_cursor_out))
-		return XqdStatusOK
+		return int32(XqdStatusOK)
 	}
 
 	// If the cursor points past our slice, return early
@@ -19,10 +19,10 @@ func xqd_multivalue(memory *Memory, data []string, addr int32, maxlen int32, cur
 
 		// Set the cursor to -1 to stop asking
 		memory.PutInt64(-1, int64(ending_cursor_out))
-		return XqdStatusOK
+		return int32(XqdStatusOK)
 	}
 
-	var v = []byte(data[cursor])
+	v := []byte(data[cursor])
 	v = append(v, '\x00')
 
 	nwritten, err := memory.WriteAt(v, int64(addr))
@@ -40,5 +40,5 @@ func xqd_multivalue(memory *Memory, data []string, addr int32, maxlen int32, cur
 
 	memory.PutInt64(int64(ec), int64(ending_cursor_out))
 
-	return XqdStatusOK
+	return int32(XqdStatusOK)
 }

--- a/xqd_request.go
+++ b/xqd_request.go
@@ -10,80 +10,91 @@ import (
 	"strings"
 )
 
-func (i *Instance) xqd_req_version_get(handle int32, version_out int32) XqdStatus {
+func (i *Instance) xqd_req_version_get(handle int32, version_out int32) int32 {
 	if i.requests.Get(int(handle)) == nil {
 		i.abilog.Printf("req_version_get: invalid handle %d", handle)
-		return XqdErrInvalidHandle
+		return int32(XqdErrInvalidHandle)
 	}
 
 	i.abilog.Printf("req_version_get: handle=%d version=%d", handle, Http11)
 	i.memory.PutUint32(uint32(Http11), int64(version_out))
-	return XqdStatusOK
+	return int32(XqdStatusOK)
 }
 
-func (i *Instance) xqd_req_version_set(handle int32, version int32) XqdStatus {
+func (i *Instance) xqd_req_version_set(handle int32, version int32) int32 {
 	i.abilog.Printf("req_version_set: handle=%d version=%d", handle, version)
 
 	if i.requests.Get(int(handle)) == nil {
 		i.abilog.Printf("req_version_set: invalid handle %d", handle)
-		return XqdErrInvalidHandle
+		return int32(XqdErrInvalidHandle)
 	}
 
 	if version != int32(Http11) {
 		i.abilog.Printf("req_version_set: invalid version %d", version)
-		return XqdErrUnsupported
+		return int32(XqdErrUnsupported)
 	}
 
-	return XqdStatusOK
+	return int32(XqdStatusOK)
 }
 
-func (i *Instance) xqd_req_cache_override_set(handle int32, tag int32, ttl int32, swr int32) XqdStatus {
+func (i *Instance) xqd_req_cache_override_set(handle int32, tag int32, ttl int32, swr int32) int32 {
 	// We don't actually *do* anything with cache overrides, since we don't have or need a cache.
 
 	if i.requests.Get(int(handle)) == nil {
 		i.abilog.Printf("req_cache_override_set: invalid handle %d", handle)
-		return XqdErrInvalidHandle
+		return int32(XqdErrInvalidHandle)
 	}
 
-	return XqdStatusOK
+	return int32(XqdStatusOK)
 }
 
-func (i *Instance) xqd_req_method_get(handle int32, addr int32, maxlen int32, nwritten_out int32) XqdStatus {
-	var r = i.requests.Get(int(handle))
+func (i *Instance) xqd_req_cache_override_set_v2(handle int32, tag int32, ttl int32, swr int32, sk int32, sk_len int32) int32 {
+	// We don't actually *do* anything with cache overrides, since we don't have or need a cache.
+
+	if i.requests.Get(int(handle)) == nil {
+		i.abilog.Printf("cache_override_v2_set: invalid handle %d", handle)
+		return int32(XqdErrInvalidHandle)
+	}
+
+	return int32(XqdStatusOK)
+}
+
+func (i *Instance) xqd_req_method_get(handle int32, addr int32, maxlen int32, nwritten_out int32) int32 {
+	r := i.requests.Get(int(handle))
 	if r == nil {
 		i.abilog.Printf("req_method_get: invalid handle %d", handle)
-		return XqdErrInvalidHandle
+		return int32(XqdErrInvalidHandle)
 	}
 
 	if int(maxlen) < len(r.Method) {
-		return XqdErrBufferLength
+		return int32(XqdErrBufferLength)
 	}
 
 	i.abilog.Printf("req_method_get: handle=%d method=%q", handle, r.Method)
 
 	nwritten, err := i.memory.WriteAt([]byte(r.Method), int64(addr))
 	if err != nil {
-		return XqdError
+		return int32(XqdError)
 	}
 
 	i.memory.PutUint32(uint32(nwritten), int64(nwritten_out))
-	return XqdStatusOK
+	return int32(XqdStatusOK)
 }
 
-func (i *Instance) xqd_req_method_set(handle int32, addr int32, size int32) XqdStatus {
-	var r = i.requests.Get(int(handle))
+func (i *Instance) xqd_req_method_set(handle int32, addr int32, size int32) int32 {
+	r := i.requests.Get(int(handle))
 	if r == nil {
-		return XqdErrInvalidHandle
+		return int32(XqdErrInvalidHandle)
 	}
 
-	var method = make([]byte, size)
-	var _, err = i.memory.ReadAt(method, int64(addr))
+	method := make([]byte, size)
+	_, err := i.memory.ReadAt(method, int64(addr))
 	if err != nil {
-		return XqdError
+		return int32(XqdError)
 	}
 
 	// Make sure the method is in the set of valid http methods
-	var methods = strings.Join([]string{
+	methods := strings.Join([]string{
 		http.MethodGet,
 		http.MethodHead,
 		http.MethodPost,
@@ -97,51 +108,51 @@ func (i *Instance) xqd_req_method_set(handle int32, addr int32, size int32) XqdS
 
 	if !strings.Contains(methods, strings.ToUpper(string(method))) {
 		i.abilog.Printf("req_method_set: invalid method=%q", method)
-		return XqdErrHttpParse
+		return int32(XqdErrHttpParse)
 	}
 
 	i.abilog.Printf("req_method_set: handle=%d method=%q", handle, method)
 
 	r.Method = strings.ToUpper(string(method))
-	return XqdStatusOK
+	return int32(XqdStatusOK)
 }
 
-func (i *Instance) xqd_req_uri_set(handle int32, addr int32, size int32) XqdStatus {
-	var r = i.requests.Get(int(handle))
+func (i *Instance) xqd_req_uri_set(handle int32, addr int32, size int32) int32 {
+	r := i.requests.Get(int(handle))
 	if r == nil {
-		return XqdErrInvalidHandle
+		return int32(XqdErrInvalidHandle)
 	}
 
-	var buf = make([]byte, size)
-	var nread, err = i.memory.ReadAt(buf, int64(addr))
+	buf := make([]byte, size)
+	nread, err := i.memory.ReadAt(buf, int64(addr))
 	if err != nil {
-		return XqdError
+		return int32(XqdError)
 	}
 	if nread < int(size) {
-		return XqdError
+		return int32(XqdError)
 	}
 
 	u, err := url.Parse(string(buf))
 	if err != nil {
 		i.abilog.Printf("req_uri_set: parse error uri=%q got=%s", buf, err.Error())
-		return XqdErrHttpParse
+		return int32(XqdErrHttpParse)
 	}
 
 	i.abilog.Printf("req_uri_set: handle=%d uri=%q", handle, u)
 
 	r.URL = u
-	return XqdStatusOK
+	return int32(XqdStatusOK)
 }
 
-func (i *Instance) xqd_req_header_names_get(handle int32, addr int32, maxlen int32, cursor int32, ending_cursor_out int32, nwritten_out int32) XqdStatus {
+func (i *Instance) xqd_req_header_names_get(handle int32, addr int32, maxlen int32, cursor int32, ending_cursor_out int32, nwritten_out int32) int32 {
 	i.abilog.Printf("req_header_names_get: handle=%d cursor=%d", handle, cursor)
 
-	var r = i.requests.Get(int(handle))
+	r := i.requests.Get(int(handle))
 	if r == nil {
-		return XqdErrInvalidHandle
+		return int32(XqdErrInvalidHandle)
 	}
 
-	var names = []string{}
+	names := []string{}
 	for n := range r.Header {
 		names = append(names, n)
 	}
@@ -149,26 +160,26 @@ func (i *Instance) xqd_req_header_names_get(handle int32, addr int32, maxlen int
 	// these names are explicitly unsorted, so let's sort them ourselves
 	sort.Strings(names[:])
 
-	return xqd_multivalue(i.memory, names, addr, maxlen, cursor, ending_cursor_out, nwritten_out)
+	return int32(xqd_multivalue(i.memory, names, addr, maxlen, cursor, ending_cursor_out, nwritten_out))
 }
 
-func (i *Instance) xqd_req_header_values_get(handle int32, name_addr int32, name_size int32, addr int32, maxlen int32, cursor int32, ending_cursor_out int32, nwritten_out int32) XqdStatus {
-	var r = i.requests.Get(int(handle))
+func (i *Instance) xqd_req_header_values_get(handle int32, name_addr int32, name_size int32, addr int32, maxlen int32, cursor int32, ending_cursor_out int32, nwritten_out int32) int32 {
+	r := i.requests.Get(int(handle))
 	if r == nil {
-		return XqdErrInvalidHandle
+		return int32(XqdErrInvalidHandle)
 	}
 
-	var buf = make([]byte, name_size)
-	var _, err = i.memory.ReadAt(buf, int64(name_addr))
+	buf := make([]byte, name_size)
+	_, err := i.memory.ReadAt(buf, int64(name_addr))
 	if err != nil {
-		return XqdError
+		return int32(XqdError)
 	}
 
-	var header = http.CanonicalHeaderKey(string(buf))
+	header := http.CanonicalHeaderKey(string(buf))
 
 	i.abilog.Printf("req_header_values_get: handle=%d header=%q cursor=%d\n", handle, header, cursor)
 
-	var values, ok = r.Header[header]
+	values, ok := r.Header[header]
 	if !ok {
 		values = []string{}
 	}
@@ -176,32 +187,32 @@ func (i *Instance) xqd_req_header_values_get(handle int32, name_addr int32, name
 	// Sort the values otherwise cursors don't work
 	sort.Strings(values[:])
 
-	return xqd_multivalue(i.memory, values, addr, maxlen, cursor, ending_cursor_out, nwritten_out)
+	return int32(xqd_multivalue(i.memory, values, addr, maxlen, cursor, ending_cursor_out, nwritten_out))
 }
 
-func (i *Instance) xqd_req_header_values_set(handle int32, name_addr int32, name_size int32, values_addr int32, values_size int32) XqdStatus {
-	var r = i.requests.Get(int(handle))
+func (i *Instance) xqd_req_header_values_set(handle int32, name_addr int32, name_size int32, values_addr int32, values_size int32) int32 {
+	r := i.requests.Get(int(handle))
 	if r == nil {
-		return XqdErrInvalidHandle
+		return int32(XqdErrInvalidHandle)
 	}
 
-	var buf = make([]byte, name_size)
-	var _, err = i.memory.ReadAt(buf, int64(name_addr))
+	buf := make([]byte, name_size)
+	_, err := i.memory.ReadAt(buf, int64(name_addr))
 	if err != nil {
-		return XqdError
+		return int32(XqdError)
 	}
 
-	var header = http.CanonicalHeaderKey(string(buf))
+	header := http.CanonicalHeaderKey(string(buf))
 
 	// read values_size bytes from values_addr for a list of \0 terminated values for the header
 	// but, read 1 less than that to avoid the trailing nul
 	buf = make([]byte, values_size-1)
 	_, err = i.memory.ReadAt(buf, int64(values_addr))
 	if err != nil {
-		return XqdError
+		return int32(XqdError)
 	}
 
-	var values = bytes.Split(buf, []byte("\x00"))
+	values := bytes.Split(buf, []byte("\x00"))
 
 	i.abilog.Printf("req_header_values_set: handle=%d header=%q values=%q\n", handle, header, values)
 
@@ -213,13 +224,13 @@ func (i *Instance) xqd_req_header_values_set(handle int32, name_addr int32, name
 		r.Header.Add(header, string(v))
 	}
 
-	return XqdStatusOK
+	return int32(XqdStatusOK)
 }
 
-func (i *Instance) xqd_req_uri_get(handle int32, addr int32, maxlen int32, nwritten_out int32) XqdStatus {
-	var r = i.requests.Get(int(handle))
+func (i *Instance) xqd_req_uri_get(handle int32, addr int32, maxlen int32, nwritten_out int32) int32 {
+	r := i.requests.Get(int(handle))
 	if r == nil {
-		return XqdErrInvalidHandle
+		return int32(XqdErrInvalidHandle)
 	}
 
 	uri := r.URL.String()
@@ -227,48 +238,48 @@ func (i *Instance) xqd_req_uri_get(handle int32, addr int32, maxlen int32, nwrit
 
 	nwritten, err := i.memory.WriteAt([]byte(uri), int64(addr))
 	if err != nil {
-		return XqdError
+		return int32(XqdError)
 	}
 
 	i.memory.PutUint32(uint32(nwritten), int64(nwritten_out))
-	return XqdStatusOK
+	return int32(XqdStatusOK)
 }
 
-func (i *Instance) xqd_req_new(handle_out int32) XqdStatus {
-	var rhid, _ = i.requests.New()
+func (i *Instance) xqd_req_new(handle_out int32) int32 {
+	rhid, _ := i.requests.New()
 	i.abilog.Printf("req_new: handle=%d", rhid)
 	i.memory.PutUint32(uint32(rhid), int64(handle_out))
-	return XqdStatusOK
+	return int32(XqdStatusOK)
 }
 
-func (i *Instance) xqd_req_send(rhandle int32, bhandle int32, backend_addr, backend_size int32, wh_out int32, bh_out int32) XqdStatus {
+func (i *Instance) xqd_req_send(rhandle int32, bhandle int32, backend_addr, backend_size int32, wh_out int32, bh_out int32) int32 {
 	// sends the request described by (rh, bh) to the backend
 	// expects a response handle and response body handle
-	var r = i.requests.Get(int(rhandle))
+	r := i.requests.Get(int(rhandle))
 	if r == nil {
 		i.abilog.Printf("req_send: invalid request handle=%d", rhandle)
-		return XqdErrInvalidHandle
+		return int32(XqdErrInvalidHandle)
 	}
 
-	var b = i.bodies.Get(int(bhandle))
+	b := i.bodies.Get(int(bhandle))
 	if b == nil {
 		i.abilog.Printf("req_send: invalid body handle=%d", bhandle)
-		return XqdErrInvalidHandle
+		return int32(XqdErrInvalidHandle)
 	}
 
-	var buf = make([]byte, backend_size)
+	buf := make([]byte, backend_size)
 	_, err := i.memory.ReadAt(buf, int64(backend_addr))
 	if err != nil {
-		return XqdError
+		return int32(XqdError)
 	}
 
-	var backend = string(buf)
+	backend := string(buf)
 
 	i.abilog.Printf("req_send: handle=%d body=%d backend=%q uri=%q", rhandle, bhandle, backend, r.URL)
 
 	req, err := http.NewRequest(r.Method, r.URL.String(), b)
 	if err != nil {
-		return XqdErrHttpUserInvalid
+		return int32(XqdErrHttpUserInvalid)
 	}
 
 	req.Header = r.Header.Clone()
@@ -307,18 +318,18 @@ func (i *Instance) xqd_req_send(rhandle int32, bhandle int32, backend_addr, back
 	w := wr.Result()
 
 	// Convert the response into an (rh, bh) pair, put them in the list, and write out the handles
-	var whid, wh = i.responses.New()
+	whid, wh := i.responses.New()
 	wh.Status = w.Status
 	wh.StatusCode = w.StatusCode
 	wh.Header = w.Header.Clone()
 	wh.Body = w.Body
 
-	var bhid, _ = i.bodies.NewReader(wh.Body)
+	bhid, _ := i.bodies.NewReader(wh.Body)
 
 	i.abilog.Printf("req_send: response handle=%d body=%d", whid, bhid)
 
 	i.memory.PutUint32(uint32(whid), int64(wh_out))
 	i.memory.PutUint32(uint32(bhid), int64(bh_out))
 
-	return XqdStatusOK
+	return int32(XqdStatusOK)
 }

--- a/xqd_response.go
+++ b/xqd_response.go
@@ -6,71 +6,71 @@ import (
 	"sort"
 )
 
-func (i *Instance) xqd_resp_new(handle_out int32) XqdStatus {
-	var whid, _ = i.responses.New()
+func (i *Instance) xqd_resp_new(handle_out int32) int32 {
+	whid, _ := i.responses.New()
 	i.abilog.Printf("resp_new handle=%d\n", whid)
 	i.memory.PutUint32(uint32(whid), int64(handle_out))
-	return XqdStatusOK
+	return int32(XqdStatusOK)
 }
 
-func (i *Instance) xqd_resp_status_set(handle int32, status int32) XqdStatus {
+func (i *Instance) xqd_resp_status_set(handle int32, status int32) int32 {
 	w := i.responses.Get(int(handle))
 	if w == nil {
-		return XqdErrInvalidHandle
+		return int32(XqdErrInvalidHandle)
 	}
 
 	i.abilog.Printf("resp_status_set: handle=%d status=%d", handle, status)
 
 	w.StatusCode = int(status)
 	w.Status = http.StatusText(w.StatusCode)
-	return XqdStatusOK
+	return int32(XqdStatusOK)
 }
 
-func (i *Instance) xqd_resp_status_get(handle int32, status_out int32) XqdStatus {
+func (i *Instance) xqd_resp_status_get(handle int32, status_out int32) int32 {
 	w := i.responses.Get(int(handle))
 	if w == nil {
-		return XqdErrInvalidHandle
+		return int32(XqdErrInvalidHandle)
 	}
 
 	i.abilog.Printf("resp_status_get: handle=%d status=%d", handle, w.StatusCode)
 	i.memory.PutUint32(uint32(w.StatusCode), int64(status_out))
-	return XqdStatusOK
+	return int32(XqdStatusOK)
 }
 
-func (i *Instance) xqd_resp_version_set(handle int32, version int32) XqdStatus {
+func (i *Instance) xqd_resp_version_set(handle int32, version int32) int32 {
 	i.abilog.Printf("resp_version_set: handle=%d version=%d", handle, version)
 
 	if i.responses.Get(int(handle)) == nil {
-		return XqdErrInvalidHandle
+		return int32(XqdErrInvalidHandle)
 	}
 
 	if HttpVersion(version) != Http11 {
 		i.abilog.Printf("resp_version_set: unsupported version=%d", version)
 	}
 
-	return XqdStatusOK
+	return int32(XqdStatusOK)
 }
 
-func (i *Instance) xqd_resp_version_get(handle int32, version_out int32) XqdStatus {
+func (i *Instance) xqd_resp_version_get(handle int32, version_out int32) int32 {
 	if i.responses.Get(int(handle)) == nil {
-		return XqdErrInvalidHandle
+		return int32(XqdErrInvalidHandle)
 	}
 
 	i.abilog.Printf("resp_version_get: handle=%d version=%d", handle, Http11)
 
 	i.memory.PutUint32(uint32(Http11), int64(version_out))
-	return XqdStatusOK
+	return int32(XqdStatusOK)
 }
 
-func (i *Instance) xqd_resp_header_names_get(handle int32, addr int32, maxlen int32, cursor int32, ending_cursor_out int32, nwritten_out int32) XqdStatus {
+func (i *Instance) xqd_resp_header_names_get(handle int32, addr int32, maxlen int32, cursor int32, ending_cursor_out int32, nwritten_out int32) int32 {
 	i.abilog.Printf("resp_header_names_get: handle=%d cursor=%d", handle, cursor)
 
-	var w = i.responses.Get(int(handle))
+	w := i.responses.Get(int(handle))
 	if w == nil {
-		return XqdErrInvalidHandle
+		return int32(XqdErrInvalidHandle)
 	}
 
-	var names = []string{}
+	names := []string{}
 	for n := range w.Header {
 		names = append(names, n)
 	}
@@ -78,23 +78,23 @@ func (i *Instance) xqd_resp_header_names_get(handle int32, addr int32, maxlen in
 	// these names are explicitly unsorted, so let's sort them ourselves
 	sort.Strings(names[:])
 
-	return xqd_multivalue(i.memory, names, addr, maxlen, cursor, ending_cursor_out, nwritten_out)
+	return int32(xqd_multivalue(i.memory, names, addr, maxlen, cursor, ending_cursor_out, nwritten_out))
 }
 
-func (i *Instance) xqd_resp_header_values_get(handle int32, name_addr int32, name_size int32, addr int32, maxlen int32, cursor int32, ending_cursor_out int32, nwritten_out int32) XqdStatus {
-	var w = i.responses.Get(int(handle))
+func (i *Instance) xqd_resp_header_values_get(handle int32, name_addr int32, name_size int32, addr int32, maxlen int32, cursor int32, ending_cursor_out int32, nwritten_out int32) int32 {
+	w := i.responses.Get(int(handle))
 	if w == nil {
-		return XqdErrInvalidHandle
+		return int32(XqdErrInvalidHandle)
 	}
 
-	var buf = make([]byte, name_size)
-	var _, err = i.memory.ReadAt(buf, int64(name_addr))
+	buf := make([]byte, name_size)
+	_, err := i.memory.ReadAt(buf, int64(name_addr))
 	if err != nil {
-		return XqdError
+		return int32(XqdError)
 	}
 
-	var header = http.CanonicalHeaderKey(string(buf))
-	var values, ok = w.Header[header]
+	header := http.CanonicalHeaderKey(string(buf))
+	values, ok := w.Header[header]
 	if !ok {
 		values = []string{}
 	}
@@ -104,32 +104,32 @@ func (i *Instance) xqd_resp_header_values_get(handle int32, name_addr int32, nam
 	// Sort the values otherwise cursors don't work
 	sort.Strings(values[:])
 
-	return xqd_multivalue(i.memory, values, addr, maxlen, cursor, ending_cursor_out, nwritten_out)
+	return int32(xqd_multivalue(i.memory, values, addr, maxlen, cursor, ending_cursor_out, nwritten_out))
 }
 
-func (i *Instance) xqd_resp_header_values_set(handle int32, name_addr int32, name_size int32, values_addr int32, values_size int32) XqdStatus {
-	var w = i.responses.Get(int(handle))
+func (i *Instance) xqd_resp_header_values_set(handle int32, name_addr int32, name_size int32, values_addr int32, values_size int32) int32 {
+	w := i.responses.Get(int(handle))
 	if w == nil {
-		return XqdErrInvalidHandle
+		return int32(XqdErrInvalidHandle)
 	}
 
-	var buf = make([]byte, name_size)
-	var _, err = i.memory.ReadAt(buf, int64(name_addr))
+	buf := make([]byte, name_size)
+	_, err := i.memory.ReadAt(buf, int64(name_addr))
 	if err != nil {
-		return XqdError
+		return int32(XqdError)
 	}
 
-	var header = http.CanonicalHeaderKey(string(buf))
+	header := http.CanonicalHeaderKey(string(buf))
 
 	// read values_size bytes from values_addr for a list of \0 terminated values for the header
 	// but, read 1 less than that to avoid the trailing nul
 	buf = make([]byte, values_size-1)
 	_, err = i.memory.ReadAt(buf, int64(values_addr))
 	if err != nil {
-		return XqdError
+		return int32(XqdError)
 	}
 
-	var values = bytes.Split(buf, []byte("\x00"))
+	values := bytes.Split(buf, []byte("\x00"))
 
 	i.abilog.Printf("resp_header_values_set: handle=%d header=%q values=%q\n", handle, header, values)
 
@@ -141,5 +141,5 @@ func (i *Instance) xqd_resp_header_values_set(handle int32, name_addr int32, nam
 		w.Header.Add(header, string(v))
 	}
 
-	return XqdStatusOK
+	return int32(XqdStatusOK)
 }


### PR DESCRIPTION
## Summary:

This PR upgrades the `wasmtime-go` module to v0.26.1, fastly.rs to v0.7, and 
the Go runtime version to 1.14.0. 

It also adds a `Makefile` to make building the test data a bit easier. 

There are many small changes throughout. Fastly has deprecated most of the 
"XQG" methods in favour of having a small set of modules that export functions. 
Most of this PR, therefore, is fixing the exported function names/modules. 

One thing that I did need to change throughout is the return types for the
exported functions. Previously we returns `XqdStatus`. But the version of 
`wasmtime` that `wasmtime-go` uses now fails the function signature validation
stating that the function types don't match. After some digging, I found that
reverting the signatures to return a bare `int32` instead of the type alias
fixes things. It's annoying, but it works. 

The API that we export is defined by the `fastly_sys` crate [here](https://docs.rs/fastly-sys/0.4.0/fastly_sys/index.html).

## Test plan:

I ran the test scenario outlined in the `README.md` (reproduced here to make 
testing easier for reviewers):

```sh
$ cd testdata; fastly compute build; cd ..
$ go run ./cmd/fastlike -wasm ./testdata/bin/main.wasm -proxy-to localhost:8000 -b localhost:5000

# in another
$ python3 -m http.server

# in a third
$ curl localhost:5000/testdata/src/main.rs 
```

The last command (`curl`) should print the `main.rs` file to the console.