### PR TITLE
Upgrade to wasmtime-go v0.29

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/Khan/fastlike
 
 go 1.14
 
-require github.com/bytecodealliance/wasmtime-go v0.26.1
+require github.com/bytecodealliance/wasmtime-go v0.29.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 github.com/bytecodealliance/wasmtime-go v0.26.1 h1:xDzNH+Iq5o4N27pmsvB8cY35feN3H4d3bS7RjddBPWQ=
 github.com/bytecodealliance/wasmtime-go v0.26.1/go.mod h1:q320gUxqyI8yB+ZqRuaJOEnGkAnHh6WtJjMaT2CW4wI=
+github.com/bytecodealliance/wasmtime-go v0.29.0 h1:NEME96y0YKAUjOkTw5/2w1OZ9TLy9FJ+Q7SWW4L/X0o=
+github.com/bytecodealliance/wasmtime-go v0.29.0/go.mod h1:q320gUxqyI8yB+ZqRuaJOEnGkAnHh6WtJjMaT2CW4wI=

--- a/instance.go
+++ b/instance.go
@@ -134,13 +134,16 @@ func (i *Instance) reset() {
 
 func (i *Instance) setup() {
 	var err error
-	i.wasm, err = i.wasmctx.linker.Instantiate(i.wasmctx.module)
+	i.wasm, err = i.wasmctx.linker.Instantiate(i.wasmctx.store, i.wasmctx.module)
 	check(err)
 
 	i.interrupt, err = i.wasmctx.store.InterruptHandle()
 	check(err)
 
-	i.memory = &Memory{&wasmMemory{mem: i.wasm.GetExport("memory").Memory()}}
+	i.memory = &Memory{&wasmMemory{
+		store: i.wasmctx.store,
+		mem:   i.wasm.GetExport(i.wasmctx.store, "memory").Memory(),
+	}}
 }
 
 // ServeHTTP serves the supplied request and response pair. This is not safe to call twice.
@@ -187,8 +190,8 @@ func (i *Instance) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// The entrypoint for a fastly compute program takes no arguments and returns nothing or an
 	// error. The program itself is responsible for getting a handle on the downstream request
 	// and sending a response downstream.
-	entry := i.wasm.GetExport("_start").Func()
-	_, err := entry.Call()
+	entry := i.wasm.GetExport(i.wasmctx.store, "_start").Func()
+	_, err := entry.Call(i.wasmctx.store)
 	donech <- struct{}{}
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)

--- a/wasmcontext.go
+++ b/wasmcontext.go
@@ -182,6 +182,7 @@ func (i *Instance) linklegacy(linker *wasmtime.Linker) {
 	linker.DefineFunc(i.wasmctx.store, "env", "xqd_resp_header_names_get", i.xqd_resp_header_names_get)
 	linker.DefineFunc(i.wasmctx.store, "env", "xqd_resp_header_values_get", i.xqd_resp_header_values_get)
 	linker.DefineFunc(i.wasmctx.store, "env", "xqd_resp_header_values_set", i.xqd_resp_header_values_set)
+	linker.DefineFunc(i.wasmctx.store, "env", "xqd_resp_send_downstream", i.xqd_resp_send_downstream)
 
 	// xqd_body.go
 	linker.DefineFunc(i.wasmctx.store, "fastly_http_body", "new", i.xqd_body_new)

--- a/wasmcontext.go
+++ b/wasmcontext.go
@@ -6,7 +6,6 @@ import (
 
 type wasmContext struct {
 	store  *wasmtime.Store
-	wasi   *wasmtime.WasiInstance
 	module *wasmtime.Module
 	linker *wasmtime.Linker
 }
@@ -17,7 +16,8 @@ func (i *Instance) compile(wasmbytes []byte) {
 	check(config.CacheConfigLoadDefault())
 	config.SetInterruptable(true)
 
-	store := wasmtime.NewStore(wasmtime.NewEngineWithConfig(config))
+	engine := wasmtime.NewEngineWithConfig(config)
+	store := wasmtime.NewStore(engine)
 	module, err := wasmtime.NewModule(store.Engine, wasmbytes)
 	check(err)
 
@@ -25,21 +25,20 @@ func (i *Instance) compile(wasmbytes []byte) {
 	wasicfg.InheritStdout()
 	wasicfg.InheritStderr()
 
-	wasi, err := wasmtime.NewWasiInstance(store, wasicfg, "wasi_snapshot_preview1")
-	check(err)
+	store.SetWasi(wasicfg)
 
-	linker := wasmtime.NewLinker(store)
-	check(linker.DefineWasi(wasi))
+	linker := wasmtime.NewLinker(engine)
+	check(linker.DefineWasi())
 
-	i.link(linker)
-	i.linklegacy(linker)
-
+	// We use
 	i.wasmctx = &wasmContext{
 		store:  store,
-		wasi:   wasi,
 		module: module,
 		linker: linker,
 	}
+
+	i.link(linker)
+	i.linklegacy(linker)
 }
 
 func (i *Instance) link(linker *wasmtime.Linker) {
@@ -47,77 +46,77 @@ func (i *Instance) link(linker *wasmtime.Linker) {
 	// TODO: All of these fastly-sys methods are stubbed. As they are
 	// implemented, they'll be removed from here and explicitly linked in the
 	// section below.
-	linker.DefineFunc("fastly_http_req", "pending_req_poll", i.wasm4("pending_req_poll"))
-	linker.DefineFunc("fastly_http_req", "pending_req_select", i.wasm5("pending_req_select"))
-	linker.DefineFunc("fastly_http_req", "pending_req_wait", i.wasm3("pending_req_wait"))
+	linker.DefineFunc(i.wasmctx.store, "fastly_http_req", "pending_req_poll", i.wasm4("pending_req_poll"))
+	linker.DefineFunc(i.wasmctx.store, "fastly_http_req", "pending_req_select", i.wasm5("pending_req_select"))
+	linker.DefineFunc(i.wasmctx.store, "fastly_http_req", "pending_req_wait", i.wasm3("pending_req_wait"))
 
-	linker.DefineFunc("fastly_http_req", "downstream_tls_cipher_openssl_name", i.wasm3("downstream_tls_cipher_openssl_name"))
-	linker.DefineFunc("fastly_http_req", "downstream_tls_protocol", i.wasm3("downstream_tls_protocol"))
-	linker.DefineFunc("fastly_http_req", "downstream_tls_client_hello", i.wasm3("downstream_tls_client_hello"))
+	linker.DefineFunc(i.wasmctx.store, "fastly_http_req", "downstream_tls_cipher_openssl_name", i.wasm3("downstream_tls_cipher_openssl_name"))
+	linker.DefineFunc(i.wasmctx.store, "fastly_http_req", "downstream_tls_protocol", i.wasm3("downstream_tls_protocol"))
+	linker.DefineFunc(i.wasmctx.store, "fastly_http_req", "downstream_tls_client_hello", i.wasm3("downstream_tls_client_hello"))
 
-	linker.DefineFunc("fastly_http_req", "header_insert", i.wasm5("header_insert"))
-	linker.DefineFunc("fastly_http_req", "send_async", i.wasm5("send_async"))
+	linker.DefineFunc(i.wasmctx.store, "fastly_http_req", "header_insert", i.wasm5("header_insert"))
+	linker.DefineFunc(i.wasmctx.store, "fastly_http_req", "send_async", i.wasm5("send_async"))
 
-	linker.DefineFunc("fastly_http_req", "original_header_count", i.wasm1("original_header_count"))
+	linker.DefineFunc(i.wasmctx.store, "fastly_http_req", "original_header_count", i.wasm1("original_header_count"))
 
-	linker.DefineFunc("fastly_http_resp", "header_append", i.wasm5("header_append"))
-	linker.DefineFunc("fastly_http_resp", "header_insert", i.wasm5("header_insert"))
-	linker.DefineFunc("fastly_http_resp", "header_value_get", i.wasm6("header_value_get"))
-	linker.DefineFunc("fastly_http_resp", "header_remove", i.wasm3("header_remove"))
+	linker.DefineFunc(i.wasmctx.store, "fastly_http_resp", "header_append", i.wasm5("header_append"))
+	linker.DefineFunc(i.wasmctx.store, "fastly_http_resp", "header_insert", i.wasm5("header_insert"))
+	linker.DefineFunc(i.wasmctx.store, "fastly_http_resp", "header_value_get", i.wasm6("header_value_get"))
+	linker.DefineFunc(i.wasmctx.store, "fastly_http_resp", "header_remove", i.wasm3("header_remove"))
 	// End fastly-sys Stubbing -}}}
 
 	// xqd.go
-	linker.DefineFunc("fastly_abi", "init", i.xqd_init)
-	linker.DefineFunc("fastly_uap", "parse", i.xqd_uap_parse)
+	linker.DefineFunc(i.wasmctx.store, "fastly_abi", "init", i.xqd_init)
+	linker.DefineFunc(i.wasmctx.store, "fastly_uap", "parse", i.xqd_uap_parse)
 
 	// xqd_request.go
-	linker.DefineFunc("fastly_http_req", "body_downstream_get", i.xqd_req_body_downstream_get)
-	linker.DefineFunc("fastly_http_req", "downstream_client_ip_addr", i.xqd_req_downstream_client_ip_addr)
-	linker.DefineFunc("fastly_http_req", "new", i.xqd_req_new)
-	linker.DefineFunc("fastly_http_req", "version_get", i.xqd_req_version_get)
-	linker.DefineFunc("fastly_http_req", "version_set", i.xqd_req_version_set)
-	linker.DefineFunc("fastly_http_req", "method_get", i.xqd_req_method_get)
-	linker.DefineFunc("fastly_http_req", "method_set", i.xqd_req_method_set)
-	linker.DefineFunc("fastly_http_req", "uri_get", i.xqd_req_uri_get)
-	linker.DefineFunc("fastly_http_req", "uri_set", i.xqd_req_uri_set)
-	linker.DefineFunc("fastly_http_req", "header_names_get", i.xqd_req_header_names_get)
-	linker.DefineFunc("fastly_http_req", "header_remove", i.xqd_req_header_remove)
-	linker.DefineFunc("fastly_http_req", "header_value_get", i.xqd_req_header_value_get)
-	linker.DefineFunc("fastly_http_req", "header_values_get", i.xqd_req_header_values_get)
-	linker.DefineFunc("fastly_http_req", "header_values_set", i.xqd_req_header_values_set)
-	linker.DefineFunc("fastly_http_req", "send", i.xqd_req_send)
-	linker.DefineFunc("fastly_http_req", "cache_override_set", i.xqd_req_cache_override_set)
-	linker.DefineFunc("fastly_http_req", "cache_override_v2_set", i.xqd_req_cache_override_v2_set)
+	linker.DefineFunc(i.wasmctx.store, "fastly_http_req", "body_downstream_get", i.xqd_req_body_downstream_get)
+	linker.DefineFunc(i.wasmctx.store, "fastly_http_req", "downstream_client_ip_addr", i.xqd_req_downstream_client_ip_addr)
+	linker.DefineFunc(i.wasmctx.store, "fastly_http_req", "new", i.xqd_req_new)
+	linker.DefineFunc(i.wasmctx.store, "fastly_http_req", "version_get", i.xqd_req_version_get)
+	linker.DefineFunc(i.wasmctx.store, "fastly_http_req", "version_set", i.xqd_req_version_set)
+	linker.DefineFunc(i.wasmctx.store, "fastly_http_req", "method_get", i.xqd_req_method_get)
+	linker.DefineFunc(i.wasmctx.store, "fastly_http_req", "method_set", i.xqd_req_method_set)
+	linker.DefineFunc(i.wasmctx.store, "fastly_http_req", "uri_get", i.xqd_req_uri_get)
+	linker.DefineFunc(i.wasmctx.store, "fastly_http_req", "uri_set", i.xqd_req_uri_set)
+	linker.DefineFunc(i.wasmctx.store, "fastly_http_req", "header_names_get", i.xqd_req_header_names_get)
+	linker.DefineFunc(i.wasmctx.store, "fastly_http_req", "header_remove", i.xqd_req_header_remove)
+	linker.DefineFunc(i.wasmctx.store, "fastly_http_req", "header_value_get", i.xqd_req_header_value_get)
+	linker.DefineFunc(i.wasmctx.store, "fastly_http_req", "header_values_get", i.xqd_req_header_values_get)
+	linker.DefineFunc(i.wasmctx.store, "fastly_http_req", "header_values_set", i.xqd_req_header_values_set)
+	linker.DefineFunc(i.wasmctx.store, "fastly_http_req", "send", i.xqd_req_send)
+	linker.DefineFunc(i.wasmctx.store, "fastly_http_req", "cache_override_set", i.xqd_req_cache_override_set)
+	linker.DefineFunc(i.wasmctx.store, "fastly_http_req", "cache_override_v2_set", i.xqd_req_cache_override_v2_set)
 	// The Go http implementation doesn't make it easy to get at the original headers in order, so
 	// we just use the same sorted order
-	linker.DefineFunc("fastly_http_req", "original_header_names_get", i.xqd_req_header_names_get)
+	linker.DefineFunc(i.wasmctx.store, "fastly_http_req", "original_header_names_get", i.xqd_req_header_names_get)
 
 	// xqd_response.go
-	linker.DefineFunc("fastly_http_resp", "send_downstream", i.xqd_resp_send_downstream)
-	linker.DefineFunc("fastly_http_resp", "new", i.xqd_resp_new)
-	linker.DefineFunc("fastly_http_resp", "status_get", i.xqd_resp_status_get)
-	linker.DefineFunc("fastly_http_resp", "status_set", i.xqd_resp_status_set)
-	linker.DefineFunc("fastly_http_resp", "version_get", i.xqd_resp_version_get)
-	linker.DefineFunc("fastly_http_resp", "version_set", i.xqd_resp_version_set)
-	linker.DefineFunc("fastly_http_resp", "header_names_get", i.xqd_resp_header_names_get)
-	linker.DefineFunc("fastly_http_resp", "header_remove", i.xqd_resp_header_remove)
-	linker.DefineFunc("fastly_http_resp", "header_values_get", i.xqd_resp_header_values_get)
-	linker.DefineFunc("fastly_http_resp", "header_values_set", i.xqd_resp_header_values_set)
+	linker.DefineFunc(i.wasmctx.store, "fastly_http_resp", "send_downstream", i.xqd_resp_send_downstream)
+	linker.DefineFunc(i.wasmctx.store, "fastly_http_resp", "new", i.xqd_resp_new)
+	linker.DefineFunc(i.wasmctx.store, "fastly_http_resp", "status_get", i.xqd_resp_status_get)
+	linker.DefineFunc(i.wasmctx.store, "fastly_http_resp", "status_set", i.xqd_resp_status_set)
+	linker.DefineFunc(i.wasmctx.store, "fastly_http_resp", "version_get", i.xqd_resp_version_get)
+	linker.DefineFunc(i.wasmctx.store, "fastly_http_resp", "version_set", i.xqd_resp_version_set)
+	linker.DefineFunc(i.wasmctx.store, "fastly_http_resp", "header_names_get", i.xqd_resp_header_names_get)
+	linker.DefineFunc(i.wasmctx.store, "fastly_http_resp", "header_remove", i.xqd_resp_header_remove)
+	linker.DefineFunc(i.wasmctx.store, "fastly_http_resp", "header_values_get", i.xqd_resp_header_values_get)
+	linker.DefineFunc(i.wasmctx.store, "fastly_http_resp", "header_values_set", i.xqd_resp_header_values_set)
 
 	// xqd_body.go
-	linker.DefineFunc("fastly_http_body", "new", i.xqd_body_new)
-	linker.DefineFunc("fastly_http_body", "write", i.xqd_body_write)
-	linker.DefineFunc("fastly_http_body", "read", i.xqd_body_read)
-	linker.DefineFunc("fastly_http_body", "append", i.xqd_body_append)
-	linker.DefineFunc("fastly_http_body", "close", i.xqd_body_close)
+	linker.DefineFunc(i.wasmctx.store, "fastly_http_body", "new", i.xqd_body_new)
+	linker.DefineFunc(i.wasmctx.store, "fastly_http_body", "write", i.xqd_body_write)
+	linker.DefineFunc(i.wasmctx.store, "fastly_http_body", "read", i.xqd_body_read)
+	linker.DefineFunc(i.wasmctx.store, "fastly_http_body", "append", i.xqd_body_append)
+	linker.DefineFunc(i.wasmctx.store, "fastly_http_body", "close", i.xqd_body_close)
 
 	// xqd_log.go
-	linker.DefineFunc("fastly_log", "endpoint_get", i.xqd_log_endpoint_get)
-	linker.DefineFunc("fastly_log", "write", i.xqd_log_write)
+	linker.DefineFunc(i.wasmctx.store, "fastly_log", "endpoint_get", i.xqd_log_endpoint_get)
+	linker.DefineFunc(i.wasmctx.store, "fastly_log", "write", i.xqd_log_write)
 
 	// xqd_dictionary.go
-	linker.DefineFunc("fastly_dictionary", "open", i.xqd_dictionary_open)
-	linker.DefineFunc("fastly_dictionary", "get", i.xqd_dictionary_get)
+	linker.DefineFunc(i.wasmctx.store, "fastly_dictionary", "open", i.xqd_dictionary_open)
+	linker.DefineFunc(i.wasmctx.store, "fastly_dictionary", "get", i.xqd_dictionary_get)
 }
 
 // linklegacy links in the abi methods using the legacy method names
@@ -125,73 +124,73 @@ func (i *Instance) linklegacy(linker *wasmtime.Linker) {
 	// XQD Stubbing -{{{
 	// TODO: All of these XQD methods are stubbed. As they are implemented, they'll be removed from
 	// here and explicitly linked in the section below.
-	linker.DefineFunc("env", "xqd_pending_req_poll", i.wasm4("xqd_pending_req_poll"))
-	linker.DefineFunc("env", "xqd_pending_req_select", i.wasm5("xqd_pending_req_select"))
-	linker.DefineFunc("env", "xqd_pending_req_wait", i.wasm3("xqd_pending_req_wait"))
+	linker.DefineFunc(i.wasmctx.store, "env", "xqd_pending_req_poll", i.wasm4("xqd_pending_req_poll"))
+	linker.DefineFunc(i.wasmctx.store, "env", "xqd_pending_req_select", i.wasm5("xqd_pending_req_select"))
+	linker.DefineFunc(i.wasmctx.store, "env", "xqd_pending_req_wait", i.wasm3("xqd_pending_req_wait"))
 
-	linker.DefineFunc("env", "xqd_req_downstream_tls_cipher_openssl_name", i.wasm3("req_downstream_tls_cipher_openssl_name"))
-	linker.DefineFunc("env", "xqd_req_downstream_tls_protocol", i.wasm3("req_downstream_tls_protocol"))
-	linker.DefineFunc("env", "xqd_req_downstream_tls_client_hello", i.wasm3("req_downstream_tls_client_hello"))
+	linker.DefineFunc(i.wasmctx.store, "env", "xqd_req_downstream_tls_cipher_openssl_name", i.wasm3("req_downstream_tls_cipher_openssl_name"))
+	linker.DefineFunc(i.wasmctx.store, "env", "xqd_req_downstream_tls_protocol", i.wasm3("req_downstream_tls_protocol"))
+	linker.DefineFunc(i.wasmctx.store, "env", "xqd_req_downstream_tls_client_hello", i.wasm3("req_downstream_tls_client_hello"))
 
-	linker.DefineFunc("env", "xqd_req_header_insert", i.wasm5("req_header_insert"))
-	linker.DefineFunc("env", "xqd_req_send_async", i.wasm5("req_send_async"))
+	linker.DefineFunc(i.wasmctx.store, "env", "xqd_req_header_insert", i.wasm5("req_header_insert"))
+	linker.DefineFunc(i.wasmctx.store, "env", "xqd_req_send_async", i.wasm5("req_send_async"))
 
-	linker.DefineFunc("env", "xqd_req_original_header_count", i.wasm1("xqd_req_original_header_count"))
+	linker.DefineFunc(i.wasmctx.store, "env", "xqd_req_original_header_count", i.wasm1("xqd_req_original_header_count"))
 
-	linker.DefineFunc("env", "xqd_resp_header_append", i.wasm5("xqd_resp_header_append"))
-	linker.DefineFunc("env", "xqd_resp_header_insert", i.wasm5("xqd_resp_header_insert"))
-	linker.DefineFunc("env", "xqd_resp_header_value_get", i.wasm6("xqd_resp_header_value_get"))
+	linker.DefineFunc(i.wasmctx.store, "env", "xqd_resp_header_append", i.wasm5("xqd_resp_header_append"))
+	linker.DefineFunc(i.wasmctx.store, "env", "xqd_resp_header_insert", i.wasm5("xqd_resp_header_insert"))
+	linker.DefineFunc(i.wasmctx.store, "env", "xqd_resp_header_value_get", i.wasm6("xqd_resp_header_value_get"))
 
-	linker.DefineFunc("env", "xqd_body_close_downstream", i.xqd_body_close)
+	linker.DefineFunc(i.wasmctx.store, "env", "xqd_body_close_downstream", i.xqd_body_close)
 	// End XQD Stubbing -}}}
 
 	// xqd.go
-	linker.DefineFunc("fastly_abi", "init", i.xqd_init)
-	linker.DefineFunc("fastly_uap", "parse", i.xqd_uap_parse)
+	linker.DefineFunc(i.wasmctx.store, "fastly_abi", "init", i.xqd_init)
+	linker.DefineFunc(i.wasmctx.store, "fastly_uap", "parse", i.xqd_uap_parse)
 
-	linker.DefineFunc("fastly_http_req", "body_downstream_get", i.xqd_req_body_downstream_get)
-	linker.DefineFunc("fastly_http_resp", "send_downstream", i.xqd_resp_send_downstream)
-	linker.DefineFunc("fastly_http_req", "downstream_client_ip_addr", i.xqd_req_downstream_client_ip_addr)
+	linker.DefineFunc(i.wasmctx.store, "fastly_http_req", "body_downstream_get", i.xqd_req_body_downstream_get)
+	linker.DefineFunc(i.wasmctx.store, "fastly_http_resp", "send_downstream", i.xqd_resp_send_downstream)
+	linker.DefineFunc(i.wasmctx.store, "fastly_http_req", "downstream_client_ip_addr", i.xqd_req_downstream_client_ip_addr)
 
 	// xqd_request.go
-	linker.DefineFunc("env", "xqd_req_new", i.xqd_req_new)
-	linker.DefineFunc("env", "xqd_req_version_get", i.xqd_req_version_get)
-	linker.DefineFunc("env", "xqd_req_version_set", i.xqd_req_version_set)
-	linker.DefineFunc("env", "xqd_req_method_get", i.xqd_req_method_get)
-	linker.DefineFunc("env", "xqd_req_method_set", i.xqd_req_method_set)
-	linker.DefineFunc("env", "xqd_req_uri_get", i.xqd_req_uri_get)
-	linker.DefineFunc("env", "xqd_req_uri_set", i.xqd_req_uri_set)
-	linker.DefineFunc("env", "xqd_req_header_remove", i.xqd_req_header_remove)
-	linker.DefineFunc("env", "xqd_req_header_names_get", i.xqd_req_header_names_get)
-	linker.DefineFunc("env", "xqd_req_header_value_get", i.xqd_req_header_value_get)
-	linker.DefineFunc("env", "xqd_req_header_values_get", i.xqd_req_header_values_get)
-	linker.DefineFunc("env", "xqd_req_header_values_set", i.xqd_req_header_values_set)
-	linker.DefineFunc("env", "xqd_req_send", i.xqd_req_send)
-	linker.DefineFunc("env", "xqd_req_cache_override_set", i.xqd_req_cache_override_set)
-	linker.DefineFunc("env", "xqd_req_cache_override_v2_set", i.xqd_req_cache_override_v2_set)
+	linker.DefineFunc(i.wasmctx.store, "env", "xqd_req_new", i.xqd_req_new)
+	linker.DefineFunc(i.wasmctx.store, "env", "xqd_req_version_get", i.xqd_req_version_get)
+	linker.DefineFunc(i.wasmctx.store, "env", "xqd_req_version_set", i.xqd_req_version_set)
+	linker.DefineFunc(i.wasmctx.store, "env", "xqd_req_method_get", i.xqd_req_method_get)
+	linker.DefineFunc(i.wasmctx.store, "env", "xqd_req_method_set", i.xqd_req_method_set)
+	linker.DefineFunc(i.wasmctx.store, "env", "xqd_req_uri_get", i.xqd_req_uri_get)
+	linker.DefineFunc(i.wasmctx.store, "env", "xqd_req_uri_set", i.xqd_req_uri_set)
+	linker.DefineFunc(i.wasmctx.store, "env", "xqd_req_header_remove", i.xqd_req_header_remove)
+	linker.DefineFunc(i.wasmctx.store, "env", "xqd_req_header_names_get", i.xqd_req_header_names_get)
+	linker.DefineFunc(i.wasmctx.store, "env", "xqd_req_header_value_get", i.xqd_req_header_value_get)
+	linker.DefineFunc(i.wasmctx.store, "env", "xqd_req_header_values_get", i.xqd_req_header_values_get)
+	linker.DefineFunc(i.wasmctx.store, "env", "xqd_req_header_values_set", i.xqd_req_header_values_set)
+	linker.DefineFunc(i.wasmctx.store, "env", "xqd_req_send", i.xqd_req_send)
+	linker.DefineFunc(i.wasmctx.store, "env", "xqd_req_cache_override_set", i.xqd_req_cache_override_set)
+	linker.DefineFunc(i.wasmctx.store, "env", "xqd_req_cache_override_v2_set", i.xqd_req_cache_override_v2_set)
 	// The Go http implementation doesn't make it easy to get at the original headers in order, so
 	// we just use the same sorted order
-	linker.DefineFunc("fastly_http_req", "original_header_names_get", i.xqd_req_header_names_get)
+	linker.DefineFunc(i.wasmctx.store, "fastly_http_req", "original_header_names_get", i.xqd_req_header_names_get)
 
 	// xqd_response.go
-	linker.DefineFunc("env", "xqd_resp_new", i.xqd_resp_new)
-	linker.DefineFunc("env", "xqd_resp_status_get", i.xqd_resp_status_get)
-	linker.DefineFunc("env", "xqd_resp_status_set", i.xqd_resp_status_set)
-	linker.DefineFunc("env", "xqd_resp_version_get", i.xqd_resp_version_get)
-	linker.DefineFunc("env", "xqd_resp_version_set", i.xqd_resp_version_set)
-	linker.DefineFunc("env", "xqd_resp_header_remove", i.xqd_resp_header_remove)
-	linker.DefineFunc("env", "xqd_resp_header_names_get", i.xqd_resp_header_names_get)
-	linker.DefineFunc("env", "xqd_resp_header_values_get", i.xqd_resp_header_values_get)
-	linker.DefineFunc("env", "xqd_resp_header_values_set", i.xqd_resp_header_values_set)
+	linker.DefineFunc(i.wasmctx.store, "env", "xqd_resp_new", i.xqd_resp_new)
+	linker.DefineFunc(i.wasmctx.store, "env", "xqd_resp_status_get", i.xqd_resp_status_get)
+	linker.DefineFunc(i.wasmctx.store, "env", "xqd_resp_status_set", i.xqd_resp_status_set)
+	linker.DefineFunc(i.wasmctx.store, "env", "xqd_resp_version_get", i.xqd_resp_version_get)
+	linker.DefineFunc(i.wasmctx.store, "env", "xqd_resp_version_set", i.xqd_resp_version_set)
+	linker.DefineFunc(i.wasmctx.store, "env", "xqd_resp_header_remove", i.xqd_resp_header_remove)
+	linker.DefineFunc(i.wasmctx.store, "env", "xqd_resp_header_names_get", i.xqd_resp_header_names_get)
+	linker.DefineFunc(i.wasmctx.store, "env", "xqd_resp_header_values_get", i.xqd_resp_header_values_get)
+	linker.DefineFunc(i.wasmctx.store, "env", "xqd_resp_header_values_set", i.xqd_resp_header_values_set)
 
 	// xqd_body.go
-	linker.DefineFunc("fastly_http_body", "new", i.xqd_body_new)
-	linker.DefineFunc("fastly_http_body", "read", i.xqd_body_read)
-	linker.DefineFunc("fastly_http_body", "write", i.xqd_body_write)
-	linker.DefineFunc("fastly_http_body", "append", i.xqd_body_append)
-	linker.DefineFunc("fastly_http_body", "close", i.xqd_body_close)
+	linker.DefineFunc(i.wasmctx.store, "fastly_http_body", "new", i.xqd_body_new)
+	linker.DefineFunc(i.wasmctx.store, "fastly_http_body", "read", i.xqd_body_read)
+	linker.DefineFunc(i.wasmctx.store, "fastly_http_body", "write", i.xqd_body_write)
+	linker.DefineFunc(i.wasmctx.store, "fastly_http_body", "append", i.xqd_body_append)
+	linker.DefineFunc(i.wasmctx.store, "fastly_http_body", "close", i.xqd_body_close)
 
 	// xqd_log.go
-	linker.DefineFunc("env", "xqd_log_endpoint_get", i.xqd_log_endpoint_get)
-	linker.DefineFunc("env", "xqd_log_write", i.xqd_log_write)
+	linker.DefineFunc(i.wasmctx.store, "env", "xqd_log_endpoint_get", i.xqd_log_endpoint_get)
+	linker.DefineFunc(i.wasmctx.store, "env", "xqd_log_write", i.xqd_log_write)
 }


### PR DESCRIPTION
## Summary:

A[ linker issue](https://github.com/bytecodealliance/wasmtime-go/issues/94) in wasmtime-go caused build failures in Linux environments. This was [fixed](https://github.com/bytecodealliance/wasmtime-go/pull/95) and shipped in [v0.29](https://github.com/bytecodealliance/wasmtime-go/releases/tag/v0.29.0) and so we need to upgrade.

This upgrade includes a wasmtime-go fix for a linker bug on Linux where the pthread library wasn't linked and caused builds to fail on Linux.
The upgrade to wasmtime-go v0.29 also includes a migration to wasmtime's new C api (https://github.com/bytecodealliance/rfcs/pull/11)

The changes were largely guided by the RFC and the [example code](https://github.com/bytecodealliance/wasmtime-go/blob/main/doc_test.go).

Issue: LP-10085

## Test plan:

`make test`